### PR TITLE
FEATURE(#430): add-battery-monitoring-capabilities

### DIFF
--- a/exp/single-source.argos
+++ b/exp/single-source.argos
@@ -16,7 +16,7 @@
   <!-- *************** -->
   <controllers>
 
-    <depth1_foraging_controller id="ffc"
+    <stateless_foraging_controller id="ffc"
                                 library="libfordyca">
       <actuators>
         <differential_steering implementation="default" />
@@ -28,6 +28,7 @@
         <footbot_light implementation="rot_z_only" show_rays="false" />
         <footbot_motor_ground implementation="rot_z_only" />
         <range_and_bearing implementation="medium" medium="rab" />
+        <battery implementation="default" />
       </sensors>
       <params>
         <output>
@@ -102,7 +103,7 @@
                               max_speed="10.0" />
         </actuation>
       </params>
-    </depth1_foraging_controller>
+    </stateless_foraging_controller>
 
   </controllers>
 
@@ -110,7 +111,7 @@
   <!-- * Loop functions * -->
   <!-- ****************** -->
   <loop_functions library="libfordyca"
-                  label="depth1_foraging_loop_functions">
+                  label="stateless_foraging_loop_functions">
     <output>
       <sim log_fname="sim.log"
            output_root="output"
@@ -230,6 +231,7 @@
       <entity quantity="64" max_trials="1000">
         <foot-bot id="fb">
           <controller config="ffc" />
+          <!-- <battery model= "time_motion"/> -->
         </foot-bot>
       </entity>
     </distribute>
@@ -254,6 +256,7 @@
   <!-- ****************** -->
   <!-- * Visualization * -->
   <!-- ****************** -->
+  <!-- </visualization> -->
   <!-- <visualization> -->
   <!--   <qt-opengl> -->
   <!--     <camera> -->

--- a/include/fordyca/controller/base_sensing_subsystem.hpp
+++ b/include/fordyca/controller/base_sensing_subsystem.hpp
@@ -29,8 +29,10 @@
 #include "rcppsw/robotics/hal/sensors/light_sensor.hpp"
 #include "rcppsw/robotics/hal/sensors/proximity_sensor.hpp"
 #include "rcppsw/robotics/hal/sensors/rab_wifi_sensor.hpp"
-
+#include "rcppsw/robotics/hal/sensors/battery_sensor.hpp"
 #include "rcppsw/common/common.hpp"
+#include <sstream>
+#include <string>
 
 /*******************************************************************************
  * Namespaces
@@ -62,6 +64,7 @@ class base_sensing_subsystem {
     hal::sensors::proximity_sensor proximity;
     hal::sensors::light_sensor light;
     hal::sensors::ground_sensor ground;
+    hal::sensors::battery_sensor battery;
   };
 
   /**
@@ -86,6 +89,9 @@ class base_sensing_subsystem {
   }
   const hal::sensors::ground_sensor& ground(void) const {
     return m_sensors.ground;
+  }
+  const hal::sensors::battery_sensor& battery(void) const {
+    return m_sensors.battery;
   }
 
   /**

--- a/src/controller/base_foraging_controller.cpp
+++ b/src/controller/base_foraging_controller.cpp
@@ -25,6 +25,7 @@
 #include <argos3/plugins/robots/foot-bot/control_interface/ci_footbot_light_sensor.h>
 #include <argos3/plugins/robots/foot-bot/control_interface/ci_footbot_motor_ground_sensor.h>
 #include <argos3/plugins/robots/foot-bot/control_interface/ci_footbot_proximity_sensor.h>
+#include <argos3/plugins/robots/generic/control_interface/ci_battery_sensor.h>
 #include <argos3/plugins/robots/generic/control_interface/ci_differential_steering_actuator.h>
 #include <argos3/plugins/robots/generic/control_interface/ci_leds_actuator.h>
 #include <argos3/plugins/robots/generic/control_interface/ci_range_and_bearing_actuator.h>
@@ -105,7 +106,9 @@ void base_foraging_controller::Init(ticpp::Element& node) {
       .light = hal::sensors::light_sensor(
           GetSensor<argos::CCI_FootBotLightSensor>("footbot_light")),
       .ground = GetSensor<argos::CCI_FootBotMotorGroundSensor>(
-          "footbot_motor_ground")};
+          "footbot_motor_ground"),
+        .battery = hal::sensors::battery_sensor(
+          GetSensor<argos::CCI_BatterySensor>("battery"))};
   m_saa = rcppsw::make_unique<controller::saa_subsystem>(
       m_server,
       param_repo.parse_results<struct params::actuation_params>(),

--- a/src/controller/depth0/stateless_foraging_controller.cpp
+++ b/src/controller/depth0/stateless_foraging_controller.cpp
@@ -23,7 +23,7 @@
  ******************************************************************************/
 #include "fordyca/controller/depth0/stateless_foraging_controller.hpp"
 #include <fstream>
-
+#include "rcppsw/include/rcppsw/robotics/hal/sensors/battery_sensor.hpp"
 #include "fordyca/controller/actuation_subsystem.hpp"
 #include "fordyca/controller/base_sensing_subsystem.hpp"
 #include "fordyca/controller/saa_subsystem.hpp"


### PR DESCRIPTION
- Implemented Battery wrapper (see swarm-robotics/rcppsw#159)
- Have Stateless Controller Print out battery info for each robot into the terminal
- The Battey tag for enabling power loss is commented out by default, so there is no need to deactivate battery when testing other things